### PR TITLE
Add natural-language formula generation via WebLLM

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,13 +28,22 @@ the feature, so the default page load is unchanged. A picker offers 0.5B
 (~0.4 GB), 1.5B (~1 GB, default) and 3B (~2 GB); switching reloads on the
 next generate. It needs a WebGPU browser (desktop Chrome or Edge).
 
-The system prompt is built at runtime from the function reference plus the
-active dataset's column names, so it stays in sync with the catalog. Each
-draft is run through the same `run_expression` parser the playground uses;
-if it fails, the parser's error is fed back to the model for one repair
-attempt before the result is shown. The default model is `WEBLLM_MODEL` in
-`assets/app.js`; the picker's options (and their `q4f16_1` quantization)
-are the `#ai-model` `<option>`s in `index.html`.
+Generation is constrained by an EBNF grammar built at runtime from the
+function list and the active dataset's columns and enforced in the browser
+by WebLLM/[XGrammar](https://xgrammar.mlc.ai) (`response_format: { type:
+"grammar" }`). The model can therefore only emit a syntactically valid
+formula that uses real function and column names — hallucinated names,
+`[..]` indexing and the like are impossible at decode time; if a model or
+engine can't honour the grammar the code falls back to plain generation.
+The system prompt is built from the same catalog so it stays in sync.
+
+As a semantic backstop each draft is still run through the
+`run_expression` parser; if it fails to execute, the error is fed back for
+a repair attempt (up to three), and formulas the parser rejects are
+remembered to steer later prompts in the session. The default model is
+`WEBLLM_MODEL` in `assets/app.js`; the picker's options (and their
+`q4f16_1` quantization) are the `#ai-model` `<option>`s in `index.html`;
+the grammar itself is `buildFormulaGrammar()`.
 
 ## Developing locally
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,8 +19,8 @@ client-side; there is no server component.
 
 ## Natural-language input (optional)
 
-The Expression panel has a **✨ Describe in words** toggle that drafts an
-expression from a plain-English description. A small instruction-tuned
+The Expression panel has a **Generate flowfile formula** button that drafts a
+formula from a plain-English description. A small instruction-tuned
 model ([Qwen2.5-1.5B-Instruct](https://huggingface.co/Qwen)) runs entirely
 client-side on WebGPU via [WebLLM](https://github.com/mlc-ai/web-llm),
 loaded on demand from the `esm.run` CDN — the model (~1 GB) is only

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,19 +21,20 @@ client-side; there is no server component.
 
 The Expression panel has a **Generate flowfile formula** button that drafts a
 formula from a plain-English description. A small instruction-tuned
-model ([Qwen2.5-1.5B-Instruct](https://huggingface.co/Qwen)) runs entirely
-client-side on WebGPU via [WebLLM](https://github.com/mlc-ai/web-llm),
-loaded on demand from the `esm.run` CDN — the model (~1 GB) is only
-downloaded when a visitor first uses the feature, so the default page load
-is unchanged. It needs a WebGPU browser (desktop Chrome or Edge).
+[Qwen2.5](https://huggingface.co/Qwen) model runs entirely client-side on
+WebGPU via [WebLLM](https://github.com/mlc-ai/web-llm), loaded on demand
+from the `esm.run` CDN — nothing is downloaded until a visitor first uses
+the feature, so the default page load is unchanged. A picker offers 0.5B
+(~0.4 GB), 1.5B (~1 GB, default) and 3B (~2 GB); switching reloads on the
+next generate. It needs a WebGPU browser (desktop Chrome or Edge).
 
 The system prompt is built at runtime from the function reference plus the
 active dataset's column names, so it stays in sync with the catalog. Each
 draft is run through the same `run_expression` parser the playground uses;
 if it fails, the parser's error is fed back to the model for one repair
-attempt before the result is shown. The model id and quantization are set
-by `WEBLLM_MODEL` near the top of the natural-language section in
-`assets/app.js` (swap in the `0.5B` id for a ~350 MB download).
+attempt before the result is shown. The default model is `WEBLLM_MODEL` in
+`assets/app.js`; the picker's options (and their `q4f16_1` quantization)
+are the `#ai-model` `<option>`s in `index.html`.
 
 ## Developing locally
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,24 @@ client-side; there is no server component.
 | `assets/functions.json` | Function reference data, generated from the library's docstrings by `../generate_docs.py`. |
 | `assets/wheel/*.whl` | The library wheel installed into Pyodide, built from this repository. |
 
+## Natural-language input (optional)
+
+The Expression panel has a **✨ Describe in words** toggle that drafts an
+expression from a plain-English description. A small instruction-tuned
+model ([Qwen2.5-1.5B-Instruct](https://huggingface.co/Qwen)) runs entirely
+client-side on WebGPU via [WebLLM](https://github.com/mlc-ai/web-llm),
+loaded on demand from the `esm.run` CDN — the model (~1 GB) is only
+downloaded when a visitor first uses the feature, so the default page load
+is unchanged. It needs a WebGPU browser (desktop Chrome or Edge).
+
+The system prompt is built at runtime from the function reference plus the
+active dataset's column names, so it stays in sync with the catalog. Each
+draft is run through the same `run_expression` parser the playground uses;
+if it fails, the parser's error is fed back to the model for one repair
+attempt before the result is shown. The model id and quantization are set
+by `WEBLLM_MODEL` near the top of the natural-language section in
+`assets/app.js` (swap in the `0.5B` id for a ~350 MB download).
+
 ## Developing locally
 
 ```bash

--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -530,6 +530,200 @@ function renderRunResult(result, elapsedMs) {
 }
 
 /* ----------------------------------------------------------------
+   Natural language → expression (optional, in-browser via WebLLM)
+
+   A small instruction-tuned model runs fully client-side on WebGPU and
+   drafts an expression from a plain-English description. The model is
+   only downloaded when the user first asks for it, so the default
+   playground load is unaffected. Whatever the model produces is checked
+   by the same parser the playground already runs (run_expression); on a
+   failure its error is fed back for one repair attempt.
+   ---------------------------------------------------------------- */
+// q4f16_1 keeps the download ~1 GB; swap to "…-q4f32_1-MLC" for GPUs
+// without shader-f16 support, or to "Qwen2.5-0.5B-Instruct-q4f16_1-MLC"
+// for a ~350 MB download with a small quality trade-off.
+const WEBLLM_MODEL = "Qwen2.5-1.5B-Instruct-q4f16_1-MLC";
+const WEBLLM_ESM = "https://esm.run/@mlc-ai/web-llm";
+
+const ai = { engine: null, loading: false, ready: false, busy: false };
+
+function aiStatus(html, kind = "") {
+  const el = $("#ai-status");
+  el.className = `ai-status ${kind}`;
+  el.innerHTML = html;
+}
+
+/* Build the system prompt from the live function reference plus the
+   columns of the active dataset. Mirrors the catalog shown in the
+   reference, so it stays in sync as functions change. */
+function buildAiSystemPrompt() {
+  const catalog = [];
+  for (const category of state.reference.categories) {
+    catalog.push(`\n[${category.label}]`);
+    for (const fn of category.functions) {
+      const desc = (fn.description || "").replace(/\s+/g, " ").split(". ")[0].replace(/\.$/, "");
+      catalog.push(`- ${fn.signature} — ${desc}`);
+    }
+  }
+  const columns = DATASETS[state.dataset].columns.map((c) => `[${c.name}]`).join(", ");
+  return [
+    "You translate a user's natural-language request into a SINGLE polars-expr-transformer expression.",
+    "",
+    "Output rules:",
+    "- Reply with ONLY the expression, on one line. No explanation, no markdown, no code fences.",
+    "- Use only the functions listed below. Never invent function names. If no function fits, build the result from operators and conditionals.",
+    "- Reference columns with square brackets, e.g. [first_name]. Spaces are allowed: [Order Date].",
+    "",
+    "Syntax:",
+    `- String literals use single or double quotes: "hello", 'world'. Numbers and booleans are bare: 42, 3.14, -7, true, false.`,
+    "- Conditionals: if <condition> then <value> elseif <condition> then <value> else <value> endif (elseif may repeat or be omitted; else is required).",
+    "- Operators: + - * / % (arithmetic; + also concatenates text) | = == != (equality) | > >= < <= (comparison) | and or (boolean) | ( ) for grouping.",
+    "- Functions may be nested: uppercase(left([last_name], 3)).",
+    "- For missing/null values use is_empty, is_not_empty, coalesce or ifnull.",
+    "",
+    `Columns in the current dataset: ${columns}. Prefer these names; only use a different [name] if the request clearly refers to one.`,
+    "",
+    "Available functions:",
+    catalog.join("\n"),
+    "",
+    "Examples (request -> expression):",
+    `"Combine first and last name with a space between them" -> concat([first_name], " ", [last_name])`,
+    `"Label anyone older than 30 as Senior, everyone else Junior" -> if [age] > 30 then "Senior" else "Junior" endif`,
+    `"Multiply price by quantity and round to 2 decimals" -> round([price] * [quantity], 2)`,
+    `"Uppercase the first three letters of the last name" -> uppercase(left([last_name], 3))`,
+    `"Use the nickname, or the full name when there is no nickname" -> coalesce([nickname], [name])`,
+    `"Grade: A for 90 or above, B for 80 or above, otherwise C" -> if [score] >= 90 then "A" elseif [score] >= 80 then "B" else "C" endif`,
+    "",
+    "Reply with only the expression.",
+  ].join("\n");
+}
+
+/* Pull a bare expression out of whatever the model returned. */
+function cleanModelOutput(text) {
+  let out = (text || "").trim();
+  const fenced = out.match(/```[a-zA-Z]*\n?([\s\S]*?)```/);
+  if (fenced) out = fenced[1].trim();
+  out = out.split(/\n\s*\n/)[0].trim();              // first paragraph only
+  out = out.replace(/^(?:->|=|expression:)\s*/i, "").trim();
+  out = out.replace(/^`+|`+$/g, "").trim();          // stray inline backticks
+  return out;
+}
+
+/* Run a candidate through the existing runtime; return null if it parses
+   and executes on the active dataset, otherwise the error message. */
+function checkExpression(expr) {
+  if (!state.ready || !state.runFn) return null;     // runtime not up yet: skip
+  try {
+    const result = JSON.parse(
+      state.runFn(JSON.stringify({ expression: expr, dataset: DATASETS[state.dataset] }))
+    );
+    return result.ok ? null : result.error || "unknown error";
+  } catch {
+    return null;                                      // never block on a harness hiccup
+  }
+}
+
+async function ensureAiEngine() {
+  if (ai.ready) return ai.engine;
+  if (ai.loading) return null;
+  if (!navigator.gpu) {
+    aiStatus(
+      "This feature needs WebGPU, which this browser doesn't expose. Try the latest desktop Chrome or Edge.",
+      "err"
+    );
+    return null;
+  }
+  ai.loading = true;
+  try {
+    aiStatus("Loading WebLLM…");
+    const webllm = await import(WEBLLM_ESM);
+    ai.engine = await webllm.CreateMLCEngine(WEBLLM_MODEL, {
+      initProgressCallback: (report) => {
+        const pct = report.progress ? ` (${Math.round(report.progress * 100)}%)` : "";
+        aiStatus(`${escapeHtml(report.text || "Loading model…")}${pct}`);
+      },
+    });
+    ai.ready = true;
+    return ai.engine;
+  } catch (error) {
+    console.error(error);
+    aiStatus(`Could not load the model: ${escapeHtml(error.message || String(error))}`, "err");
+    return null;
+  } finally {
+    ai.loading = false;
+  }
+}
+
+async function generateFromNl() {
+  const nl = $("#ai-input").value.trim();
+  if (!nl) return $("#ai-input").focus();
+  if (ai.busy) return;
+  if (!state.reference) {
+    return aiStatus("The function reference hasn't loaded yet — try again in a moment.", "err");
+  }
+
+  const engine = await ensureAiEngine();
+  if (!engine) return;
+
+  ai.busy = true;
+  $("#ai-generate").disabled = true;
+  try {
+    const messages = [
+      { role: "system", content: buildAiSystemPrompt() },
+      { role: "user", content: nl },
+    ];
+    let expr = "";
+    for (let attempt = 0; attempt < 2; attempt++) {
+      aiStatus(attempt === 0 ? "Thinking…" : "Fixing the expression…");
+      const reply = await engine.chat.completions.create({
+        messages,
+        temperature: 0.2,
+        max_tokens: 256,
+      });
+      expr = cleanModelOutput(reply.choices?.[0]?.message?.content);
+      const problem = expr ? checkExpression(expr) : "empty response";
+      if (!problem) break;
+      // Hand the parser's own error back for a single repair attempt.
+      messages.push({ role: "assistant", content: expr });
+      messages.push({
+        role: "user",
+        content: `That expression failed with this error:\n${problem}\nReturn a corrected expression. Reply with only the expression.`,
+      });
+    }
+    if (!expr) {
+      return aiStatus("The model didn't return an expression — try rephrasing.", "err");
+    }
+    setExpression(expr);                              // fills the editor and runs it
+    aiStatus(`Generated from “${escapeHtml(nl)}”. Review it above and tweak as needed.`, "ok");
+  } catch (error) {
+    console.error(error);
+    aiStatus(`Generation failed: ${escapeHtml(error.message || String(error))}`, "err");
+  } finally {
+    ai.busy = false;
+    $("#ai-generate").disabled = false;
+  }
+}
+
+function setupAi() {
+  const toggle = $("#ai-toggle");
+  const panel = $("#ai-panel");
+  if (!toggle || !panel) return;
+  toggle.addEventListener("click", () => {
+    const open = !panel.classList.toggle("hidden");
+    toggle.setAttribute("aria-expanded", String(open));
+    toggle.classList.toggle("active", open);
+    if (open) $("#ai-input").focus();
+  });
+  $("#ai-generate").addEventListener("click", generateFromNl);
+  $("#ai-input").addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      generateFromNl();
+    }
+  });
+}
+
+/* ----------------------------------------------------------------
    Output tabs / copy / share
    ---------------------------------------------------------------- */
 function setupOutputTabs() {
@@ -735,6 +929,7 @@ async function init() {
   setupShare();
   setupSearch();
   setupThemeToggle();
+  setupAi();
 
   $("#run-btn").addEventListener("click", () => runExpression());
 

--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -545,12 +545,21 @@ function renderRunResult(result, elapsedMs) {
 const WEBLLM_MODEL = "Qwen2.5-1.5B-Instruct-q4f16_1-MLC";
 const WEBLLM_ESM = "https://esm.run/@mlc-ai/web-llm";
 
-const ai = { engine: null, loading: false, ready: false, busy: false };
+const ai = { engine: null, loading: false, ready: false, busy: false, lessons: [] };
 
 function aiStatus(html, kind = "") {
   const el = $("#ai-status");
   el.className = `ai-status ${kind}`;
   el.innerHTML = html;
+}
+
+/* Remember formulas the parser rejected so later prompts can avoid
+   repeating them. Kept bounded so the prompt stays small. */
+function rememberLesson(expr, error) {
+  const note = `${expr} — ${String(error).split("\n")[0]}`;
+  if (ai.lessons.includes(note)) return;
+  ai.lessons.push(note);
+  if (ai.lessons.length > 6) ai.lessons.shift();
 }
 
 /* Build the system prompt from the live function reference plus the
@@ -566,18 +575,20 @@ function buildAiSystemPrompt() {
     }
   }
   const columns = DATASETS[state.dataset].columns.map((c) => `[${c.name}]`).join(", ");
-  return [
-    "You translate a user's natural-language request into a SINGLE polars-expr-transformer expression.",
+  const parts = [
+    "You translate a user's natural-language request into a SINGLE polars-expr-transformer formula.",
     "",
     "Output rules:",
-    "- Reply with ONLY the expression, on one line. No explanation, no markdown, no code fences.",
-    "- Use only the functions listed below. Never invent function names. If no function fits, build the result from operators and conditionals.",
+    "- Reply with ONLY the formula, on one line. No explanation, no markdown, no code fences.",
+    "- Use the functions listed below with their names spelled exactly as shown (for example uppercase, not upper; lowercase, not lower). Never invent function names.",
+    "- If no function fits, build the result from operators and conditionals.",
     "- Reference columns with square brackets, e.g. [first_name]. Spaces are allowed: [Order Date].",
     "",
     "Syntax:",
     `- String literals use single or double quotes: "hello", 'world'. Numbers and booleans are bare: 42, 3.14, -7, true, false.`,
     "- Conditionals: if <condition> then <value> elseif <condition> then <value> else <value> endif (elseif may repeat or be omitted; else is required).",
     "- Operators: + - * / % (arithmetic; + also concatenates text) | = == != (equality) | > >= < <= (comparison) | and or (boolean) | ( ) for grouping.",
+    "- There is no [..] indexing or slicing. For the last character of text use right([col], 1); for the first, left([col], 1); for the middle, mid([col], start, length).",
     "- Functions may be nested: uppercase(left([last_name], 3)).",
     "- For missing/null values use is_empty, is_not_empty, coalesce or ifnull.",
     "",
@@ -586,16 +597,21 @@ function buildAiSystemPrompt() {
     "Available functions:",
     catalog.join("\n"),
     "",
-    "Examples (request -> expression):",
+    "Examples (request -> formula):",
     `"Combine first and last name with a space between them" -> concat([first_name], " ", [last_name])`,
     `"Label anyone older than 30 as Senior, everyone else Junior" -> if [age] > 30 then "Senior" else "Junior" endif`,
     `"Multiply price by quantity and round to 2 decimals" -> round([price] * [quantity], 2)`,
     `"Uppercase the first three letters of the last name" -> uppercase(left([last_name], 3))`,
+    `"Last letter of the first name" -> right([first_name], 1)`,
     `"Use the nickname, or the full name when there is no nickname" -> coalesce([nickname], [name])`,
     `"Grade: A for 90 or above, B for 80 or above, otherwise C" -> if [score] >= 90 then "A" elseif [score] >= 80 then "B" else "C" endif`,
-    "",
-    "Reply with only the expression.",
-  ].join("\n");
+  ];
+  if (ai.lessons.length) {
+    parts.push("", "Avoid these formulas the parser rejected earlier in this session:");
+    for (const lesson of ai.lessons) parts.push(`- ${lesson}`);
+  }
+  parts.push("", "Reply with only the formula.");
+  return parts.join("\n");
 }
 
 /* Pull a bare expression out of whatever the model returned. */
@@ -668,33 +684,42 @@ async function generateFromNl() {
   ai.busy = true;
   $("#ai-generate").disabled = true;
   try {
+    if (typeof engine.resetChat === "function") await engine.resetChat();  // fresh session each generation
+
     const messages = [
       { role: "system", content: buildAiSystemPrompt() },
       { role: "user", content: nl },
     ];
     let expr = "";
-    for (let attempt = 0; attempt < 2; attempt++) {
+    let problem = null;
+    for (let attempt = 0; attempt < 3; attempt++) {
       aiStatus(attempt === 0 ? "Generating…" : "Adjusting the formula…");
       const reply = await engine.chat.completions.create({
         messages,
-        temperature: 0.2,
+        temperature: 0.1,
         max_tokens: 256,
       });
       expr = cleanModelOutput(reply.choices?.[0]?.message?.content);
-      const problem = expr ? checkExpression(expr) : "empty response";
+      problem = expr ? checkExpression(expr) : "empty response";
       if (!problem) break;
-      // Hand the parser's own error back for a single repair attempt.
+      rememberLesson(expr, problem);                  // carry the mistake into later prompts
+      // Hand the parser's own error back so the model can correct itself.
       messages.push({ role: "assistant", content: expr });
       messages.push({
         role: "user",
-        content: `That expression failed with this error:\n${problem}\nReturn a corrected expression. Reply with only the expression.`,
+        content: `That formula is not valid. The parser said:\n${problem}\nReturn a corrected formula. Reply with only the formula.`,
       });
     }
     if (!expr) {
-      return aiStatus("The model didn't return an expression — try rephrasing.", "err");
+      return aiStatus("The model didn't return a formula — try rephrasing.", "err");
     }
     setExpression(expr);                              // fills the editor and runs it
-    aiStatus(`Generated from “${escapeHtml(nl)}”. Review it above and tweak as needed.`, "ok");
+    aiStatus(
+      problem
+        ? "Generated a formula, but it didn't pass the parser — review and fix it below."
+        : `Generated from “${escapeHtml(nl)}”. Review it above and tweak as needed.`,
+      problem ? "err" : "ok"
+    );
   } catch (error) {
     console.error(error);
     aiStatus(`Generation failed: ${escapeHtml(error.message || String(error))}`, "err");

--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -553,6 +553,7 @@ const ai = {
   lessons: [],
   model: WEBLLM_MODEL,   // currently selected model id
   loadedModel: null,     // model id actually loaded into the engine
+  useGrammar: true,      // constrain decoding to the formula grammar (XGrammar)
 };
 
 function aiStatus(html, kind = "") {
@@ -620,6 +621,58 @@ function buildAiSystemPrompt() {
   }
   parts.push("", "Reply with only the formula.");
   return parts.join("\n");
+}
+
+/* Build an EBNF grammar for the formula language from the live function
+   list and the active dataset's columns. Passed to WebLLM as a grammar
+   response_format so the model can only emit a syntactically valid formula
+   that uses real function and column names — hallucinated names, [..]
+   indexing and the like become impossible at decode time. Validated with
+   XGrammar; the downstream parser remains the semantic backstop. */
+function buildFormulaGrammar() {
+  const esc = (s) => s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  const fnames = state.reference.categories.flatMap((c) => c.functions.map((f) => f.name));
+  const cols = DATASETS[state.dataset].columns.map((c) => c.name);
+  return [
+    "root ::= ws expr ws",
+    "expr ::= term (ws op ws term)*",
+    "term ::= call | cond | group | col | str | num | bool",
+    'group ::= "(" ws expr ws ")"',
+    'call ::= fname ws "(" ws arglist? ws ")"',
+    'arglist ::= expr (ws "," ws expr)*',
+    'cond ::= "if" ws expr ws "then" ws expr ws elseifs "else" ws expr ws "endif"',
+    'elseifs ::= ("elseif" ws expr ws "then" ws expr ws)*',
+    'col ::= "[" colname "]"',
+    'str ::= "\\"" dqchar* "\\"" | "\'" sqchar* "\'"',
+    'dqchar ::= [^"\\n]',
+    "sqchar ::= [^'\\n]",
+    'num ::= "-"? digit+ ("." digit+)?',
+    "digit ::= [0-9]",
+    'bool ::= "true" | "false"',
+    'op ::= "==" | "!=" | ">=" | "<=" | "+" | "-" | "*" | "/" | "%" | "=" | ">" | "<" | "and" | "or"',
+    "fname ::= " + fnames.map((n) => `"${esc(n)}"`).join(" | "),
+    "colname ::= " + cols.map((c) => `"${esc(c)}"`).join(" | "),
+    "ws ::= [ \\t\\n]*",
+  ].join("\n");
+}
+
+/* One model call, grammar-constrained when supported. Falls back to plain
+   generation (prompt rules + parser repair loop) if the engine rejects the
+   grammar response_format, and remembers that for the session. */
+async function aiComplete(messages) {
+  const base = { messages, temperature: 0.1, max_tokens: 256 };
+  if (ai.useGrammar) {
+    try {
+      return await ai.engine.chat.completions.create({
+        ...base,
+        response_format: { type: "grammar", grammar: buildFormulaGrammar() },
+      });
+    } catch (error) {
+      console.warn("Grammar-constrained generation unavailable; using the prompt only.", error);
+      ai.useGrammar = false;
+    }
+  }
+  return await ai.engine.chat.completions.create(base);
 }
 
 /* Pull a bare expression out of whatever the model returned. */
@@ -707,11 +760,7 @@ async function generateFromNl() {
     let problem = null;
     for (let attempt = 0; attempt < 3; attempt++) {
       aiStatus(attempt === 0 ? "Generating…" : "Adjusting the formula…");
-      const reply = await engine.chat.completions.create({
-        messages,
-        temperature: 0.1,
-        max_tokens: 256,
-      });
+      const reply = await aiComplete(messages);
       expr = cleanModelOutput(reply.choices?.[0]?.message?.content);
       problem = expr ? checkExpression(expr) : "empty response";
       if (!problem) break;

--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -674,7 +674,7 @@ async function generateFromNl() {
     ];
     let expr = "";
     for (let attempt = 0; attempt < 2; attempt++) {
-      aiStatus(attempt === 0 ? "Thinking…" : "Fixing the expression…");
+      aiStatus(attempt === 0 ? "Generating…" : "Adjusting the formula…");
       const reply = await engine.chat.completions.create({
         messages,
         temperature: 0.2,

--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -539,13 +539,21 @@ function renderRunResult(result, elapsedMs) {
    by the same parser the playground already runs (run_expression); on a
    failure its error is fed back for one repair attempt.
    ---------------------------------------------------------------- */
-// q4f16_1 keeps the download ~1 GB; swap to "…-q4f32_1-MLC" for GPUs
-// without shader-f16 support, or to "Qwen2.5-0.5B-Instruct-q4f16_1-MLC"
-// for a ~350 MB download with a small quality trade-off.
+// Default model; users switch sizes via the #ai-model picker. q4f16_1 needs
+// shader-f16 support (most modern GPUs) — swap the ids in index.html to the
+// "…-q4f32_1-MLC" variants for GPUs without it.
 const WEBLLM_MODEL = "Qwen2.5-1.5B-Instruct-q4f16_1-MLC";
 const WEBLLM_ESM = "https://esm.run/@mlc-ai/web-llm";
 
-const ai = { engine: null, loading: false, ready: false, busy: false, lessons: [] };
+const ai = {
+  engine: null,
+  loading: false,
+  ready: false,
+  busy: false,
+  lessons: [],
+  model: WEBLLM_MODEL,   // currently selected model id
+  loadedModel: null,     // model id actually loaded into the engine
+};
 
 function aiStatus(html, kind = "") {
   const el = $("#ai-status");
@@ -640,7 +648,7 @@ function checkExpression(expr) {
 }
 
 async function ensureAiEngine() {
-  if (ai.ready) return ai.engine;
+  if (ai.ready && ai.loadedModel === ai.model) return ai.engine;  // already loaded
   if (ai.loading) return null;
   if (!navigator.gpu) {
     aiStatus(
@@ -651,15 +659,20 @@ async function ensureAiEngine() {
   }
   ai.loading = true;
   try {
+    if (ai.engine && typeof ai.engine.unload === "function") {
+      await ai.engine.unload();        // free the previous model before switching
+    }
+    ai.ready = false;
     aiStatus("Loading WebLLM…");
     const webllm = await import(WEBLLM_ESM);
-    ai.engine = await webllm.CreateMLCEngine(WEBLLM_MODEL, {
+    ai.engine = await webllm.CreateMLCEngine(ai.model, {
       initProgressCallback: (report) => {
         const pct = report.progress ? ` (${Math.round(report.progress * 100)}%)` : "";
         aiStatus(`${escapeHtml(report.text || "Loading model…")}${pct}`);
       },
     });
     ai.ready = true;
+    ai.loadedModel = ai.model;
     return ai.engine;
   } catch (error) {
     console.error(error);
@@ -739,6 +752,16 @@ function setupAi() {
     toggle.classList.toggle("active", open);
     if (open) $("#ai-input").focus();
   });
+  const modelSelect = $("#ai-model");
+  if (modelSelect) {
+    modelSelect.value = ai.model;
+    modelSelect.addEventListener("change", () => {
+      ai.model = modelSelect.value;
+      if (ai.loadedModel && ai.loadedModel !== ai.model) {
+        aiStatus("Model changed — it will download on the next generate.");
+      }
+    });
+  }
   $("#ai-generate").addEventListener("click", generateFromNl);
   $("#ai-input").addEventListener("keydown", (event) => {
     if (event.key === "Enter") {

--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -600,6 +600,7 @@ function buildAiSystemPrompt() {
     "- There is no [..] indexing or slicing. For the last character of text use right([col], 1); for the first, left([col], 1); for the middle, mid([col], start, length).",
     "- Functions may be nested: uppercase(left([last_name], 3)).",
     "- For missing/null values use is_empty, is_not_empty, coalesce or ifnull.",
+    "- To read a part of a date use year([col]), month([col]), day([col]), hour([col]), weekday([col]), etc. to_date / to_datetime only convert text into a date — never use them to extract a part.",
     "",
     `Columns in the current dataset: ${columns}. Prefer these names; only use a different [name] if the request clearly refers to one.`,
     "",
@@ -612,6 +613,7 @@ function buildAiSystemPrompt() {
     `"Multiply price by quantity and round to 2 decimals" -> round([price] * [quantity], 2)`,
     `"Uppercase the first three letters of the last name" -> uppercase(left([last_name], 3))`,
     `"Last letter of the first name" -> right([first_name], 1)`,
+    `"Get the year from the start date" -> year([start])`,
     `"Use the nickname, or the full name when there is no nickname" -> coalesce([nickname], [name])`,
     `"Grade: A for 90 or above, B for 80 or above, otherwise C" -> if [score] >= 90 then "A" elseif [score] >= 80 then "B" else "C" endif`,
   ];

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -322,6 +322,14 @@ h1, h2, h3 { line-height: 1.25; }
   border-bottom: 1px solid var(--border);
 }
 .ai-row { display: flex; gap: 8px; flex-wrap: wrap; }
+.ai-row-sub { margin-top: 8px; align-items: center; }
+.ai-model-label { font-size: 12.5px; font-weight: 600; color: var(--text-dim); }
+.ai-model {
+  background: var(--panel); border: 1px solid var(--border); color: var(--text);
+  border-radius: 8px; padding: 5px 10px; font-size: 13px; font-family: var(--sans);
+  cursor: pointer; outline: none;
+}
+.ai-model:focus { border-color: var(--accent); }
 .ai-input {
   flex: 1 1 280px; min-width: 0;
   background: var(--panel); border: 1px solid var(--border); color: var(--text);

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -305,6 +305,34 @@ h1, h2, h3 { line-height: 1.25; }
 .ac-name.ac-col { color: var(--col); }
 .ac-detail { color: var(--text-dim); font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
+/* ---------------- natural-language input (WebLLM) ---------------- */
+.head-tools { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+.ai-toggle {
+  background: var(--accent-tint); color: var(--accent-dark);
+  border: 1px solid transparent; border-radius: 999px;
+  padding: 3px 12px; font-size: 12.5px; font-weight: 600; cursor: pointer;
+  font-family: var(--sans);
+}
+.ai-toggle:hover, .ai-toggle.active { border-color: var(--accent); }
+[data-theme="dark"] .ai-toggle { color: var(--accent); }
+
+.ai-panel {
+  padding: 12px 14px;
+  background: var(--accent-tint);
+  border-bottom: 1px solid var(--border);
+}
+.ai-row { display: flex; gap: 8px; flex-wrap: wrap; }
+.ai-input {
+  flex: 1 1 280px; min-width: 0;
+  background: var(--panel); border: 1px solid var(--border); color: var(--text);
+  border-radius: 8px; padding: 9px 13px; font-size: 14px; outline: none;
+  font-family: var(--sans);
+}
+.ai-input:focus { border-color: var(--accent); }
+.ai-status { margin: 10px 2px 0; font-size: 12.5px; color: var(--text-dim); line-height: 1.5; }
+.ai-status.ok { color: var(--ok); }
+.ai-status.err { color: var(--danger); }
+
 /* ---------------- output ---------------- */
 .workbench-divider {
   background: var(--panel-head);

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -308,13 +308,13 @@ h1, h2, h3 { line-height: 1.25; }
 /* ---------------- natural-language input (WebLLM) ---------------- */
 .head-tools { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
 .ai-toggle {
-  background: var(--accent-tint); color: var(--accent-dark);
-  border: 1px solid transparent; border-radius: 999px;
-  padding: 3px 12px; font-size: 12.5px; font-weight: 600; cursor: pointer;
-  font-family: var(--sans);
+  background: var(--accent); color: #ffffff;
+  border: 1px solid var(--accent-dark); border-radius: 999px;
+  padding: 6px 16px; font-size: 13px; font-weight: 700; cursor: pointer;
+  font-family: var(--sans); white-space: nowrap;
 }
-.ai-toggle:hover, .ai-toggle.active { border-color: var(--accent); }
-[data-theme="dark"] .ai-toggle { color: var(--accent); }
+.ai-toggle:hover, .ai-toggle.active { background: var(--accent-dark); }
+[data-theme="dark"] .ai-toggle { color: #16245e; border-color: transparent; }
 
 .ai-panel {
   padding: 12px 14px;
@@ -330,6 +330,7 @@ h1, h2, h3 { line-height: 1.25; }
 }
 .ai-input:focus { border-color: var(--accent); }
 .ai-status { margin: 10px 2px 0; font-size: 12.5px; color: var(--text-dim); line-height: 1.5; }
+.ai-status:empty { display: none; }
 .ai-status.ok { color: var(--ok); }
 .ai-status.err { color: var(--danger); }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -103,6 +103,14 @@
                 placeholder="Describe the column you want — e.g. combine first and last name with a space">
               <button id="ai-generate" class="btn btn-primary btn-sm" type="button">Generate ▸</button>
             </div>
+            <div class="ai-row ai-row-sub">
+              <label class="ai-model-label" for="ai-model">Model</label>
+              <select id="ai-model" class="ai-model" title="Larger models are more accurate but download more on first use">
+                <option value="Qwen2.5-0.5B-Instruct-q4f16_1-MLC">0.5B · fastest (~0.4 GB)</option>
+                <option value="Qwen2.5-1.5B-Instruct-q4f16_1-MLC" selected>1.5B · balanced (~1 GB)</option>
+                <option value="Qwen2.5-3B-Instruct-q4f16_1-MLC">3B · most accurate (~2 GB)</option>
+              </select>
+            </div>
             <p class="ai-status" id="ai-status"></p>
           </div>
           <div class="editor-shell">

--- a/docs/index.html
+++ b/docs/index.html
@@ -71,8 +71,8 @@
       <p class="section-intro">
         Pick a dataset and type an expression. The result and the generated
         Polars and FlowFrame code update as you type. Everything runs in your
-        browser. Not sure of the syntax? Hit <strong>✨ Describe in words</strong>
-        to draft an expression from a plain-English description.
+        browser. Not sure of the syntax? Describe what you want in plain
+        English and <strong>generate a flowfile formula</strong>.
       </p>
 
       <div id="runtime-status" class="runtime-status loading">
@@ -93,7 +93,7 @@
           <div class="panel-head">
             <span class="panel-title">Expression</span>
             <div class="head-tools">
-              <button id="ai-toggle" class="ai-toggle" type="button" aria-expanded="false" aria-controls="ai-panel" title="Draft an expression from a plain-English description">✨ Describe in words</button>
+              <button id="ai-toggle" class="ai-toggle" type="button" aria-expanded="false" aria-controls="ai-panel" title="Describe what you want and generate a flowfile formula">Generate flowfile formula</button>
               <span class="kbd-hint">Ctrl/⌘ + Enter to run</span>
             </div>
           </div>
@@ -103,12 +103,7 @@
                 placeholder="Describe the column you want — e.g. combine first and last name with a space">
               <button id="ai-generate" class="btn btn-primary btn-sm" type="button">Generate ▸</button>
             </div>
-            <p class="ai-status" id="ai-status">
-              Runs a small language model (Qwen2.5&nbsp;1.5B) entirely in your browser via
-              <a href="https://github.com/mlc-ai/web-llm" target="_blank" rel="noopener">WebLLM</a>.
-              The first use downloads it (~1&nbsp;GB, then cached) and needs a WebGPU browser
-              (desktop Chrome or Edge). The draft is checked by the parser and shown below for you to review.
-            </p>
+            <p class="ai-status" id="ai-status"></p>
           </div>
           <div class="editor-shell">
             <pre class="editor-highlight" id="editor-highlight" aria-hidden="true"></pre>

--- a/docs/index.html
+++ b/docs/index.html
@@ -71,7 +71,8 @@
       <p class="section-intro">
         Pick a dataset and type an expression. The result and the generated
         Polars and FlowFrame code update as you type. Everything runs in your
-        browser.
+        browser. Not sure of the syntax? Hit <strong>✨ Describe in words</strong>
+        to draft an expression from a plain-English description.
       </p>
 
       <div id="runtime-status" class="runtime-status loading">
@@ -91,7 +92,23 @@
         <div class="panel workbench">
           <div class="panel-head">
             <span class="panel-title">Expression</span>
-            <span class="kbd-hint">Ctrl/⌘ + Enter to run</span>
+            <div class="head-tools">
+              <button id="ai-toggle" class="ai-toggle" type="button" aria-expanded="false" aria-controls="ai-panel" title="Draft an expression from a plain-English description">✨ Describe in words</button>
+              <span class="kbd-hint">Ctrl/⌘ + Enter to run</span>
+            </div>
+          </div>
+          <div class="ai-panel hidden" id="ai-panel">
+            <div class="ai-row">
+              <input type="text" id="ai-input" class="ai-input" autocomplete="off" spellcheck="false"
+                placeholder="Describe the column you want — e.g. combine first and last name with a space">
+              <button id="ai-generate" class="btn btn-primary btn-sm" type="button">Generate ▸</button>
+            </div>
+            <p class="ai-status" id="ai-status">
+              Runs a small language model (Qwen2.5&nbsp;1.5B) entirely in your browser via
+              <a href="https://github.com/mlc-ai/web-llm" target="_blank" rel="noopener">WebLLM</a>.
+              The first use downloads it (~1&nbsp;GB, then cached) and needs a WebGPU browser
+              (desktop Chrome or Edge). The draft is checked by the parser and shown below for you to review.
+            </p>
           </div>
           <div class="editor-shell">
             <pre class="editor-highlight" id="editor-highlight" aria-hidden="true"></pre>


### PR DESCRIPTION
## Summary

This PR adds an optional natural-language-to-formula generation feature to the playground. Users can now describe what they want in plain English and have a small instruction-tuned LLM draft a formula, which is then validated and refined through the existing parser.

## Key Changes

- **WebLLM integration**: Added client-side LLM inference via WebGPU using the Qwen2.5 model family (0.5B, 1.5B, 3B variants). Models are downloaded on-demand from the esm.run CDN, so the default page load is unaffected.

- **Grammar-constrained generation**: Built an EBNF grammar at runtime from the live function reference and active dataset columns. The grammar is passed to WebLLM as a `response_format` to ensure the model can only emit syntactically valid formulas with real function and column names—hallucinating names or invalid syntax becomes impossible at decode time.

- **Semantic validation loop**: Each generated formula is run through the existing `run_expression` parser. If it fails, the error is fed back to the model for up to two repair attempts. Rejected formulas are remembered in the session to steer later prompts away from similar mistakes.

- **UI components**: Added a "Generate flowfile formula" button in the Expression panel header that toggles a collapsible input area with a text field, generate button, and model size picker. Status messages show generation progress, errors, and validation results.

- **Fallback handling**: If the engine doesn't support grammar-constrained generation, the code gracefully falls back to plain generation with prompt rules only. Browser compatibility is checked (WebGPU required) with a helpful error message.

## Implementation Details

- System prompt is dynamically built from the function catalog and dataset columns to keep it in sync with runtime changes
- Model switching unloads the previous model before loading a new one to free GPU memory
- `cleanModelOutput()` extracts the bare formula from various response formats (markdown fences, explanations, etc.)
- `checkExpression()` validates candidates against the runtime without blocking on harness errors
- The feature is entirely optional and doesn't affect existing functionality

https://claude.ai/code/session_01J52g9qrBgbypCq5PEYqRPi